### PR TITLE
Change requirements to pywal16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     entry_points={"console_scripts": ["pywalc=pywalc.__main__:main"]},
     python_requires=">=3.5",
     install_requires=[
-        "pywal>=3.3.0",
+        "pywal16>=3.7.2",
         "fastapi>=0.97.0",
         "uvicorn>=0.22.0",
         "pycloudflared>=0.2.0",


### PR DESCRIPTION
pywal will be officially unmaintained for 6 years in one month and 14 days, as of version 3.7.2 pywal16 is completely backwards compatible with pywal API wise so programs that aren't making explicit use of pywal16's specific features can use pywal16 as a drop in replacement library.